### PR TITLE
Changed fontsizes list to support longer addresses

### DIFF
--- a/main.py
+++ b/main.py
@@ -215,7 +215,7 @@ def main():
         x["country"] = [s.lower() for s in x["country"]]
 
     padding = 4
-    fontsizes = [16, 14, 12]
+    fontsizes = [16, 14, 12, 10, 8, 6, 4]
 
     # create the canvas
     canvas = Canvas(args.output, pagesize=(label["paper"]["width"], label["paper"]["height"]))


### PR DESCRIPTION
Found an issue where if an address was too long to fit inside the space for a label the font size would default to the largest size available and would then overlap with the next label. 

I modified the fontsizes list to support the longer addresses. 

Other than this small change the code worked perfectly, thanks a lot!